### PR TITLE
Fix build errors and update deprecated packages

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -58,6 +58,9 @@
   .card {
     @apply bg-card text-card-foreground shadow-sm rounded-lg border border;
   }
+  .text-card-foreground {
+    color: var(--card-foreground);
+  }
 }
 
 /* Button styling */


### PR DESCRIPTION
Fix the build error related to the `text-card-foreground` class in `src/app/globals.css`.

* Define the `text-card-foreground` class within the `@layer components` directive.
* Apply the `text-card-foreground` class to set the text color to `var(--card-foreground)`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GaryOcean428/Gary8/pull/61?shareId=eb63fbcc-442a-4af1-90f5-cabe4ec82f88).